### PR TITLE
fix: excerptから見出しテキストを除外する

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -45,6 +45,49 @@ export const onCreateNode: GatsbyNode["onCreateNode"] = ({
   }
 }
 
+export const createResolvers: GatsbyNode["createResolvers"] = ({
+  createResolvers,
+}) => {
+  createResolvers({
+    Mdx: {
+      excerpt: {
+        type: "String",
+        args: {
+          pruneLength: { type: "Int", defaultValue: 140 },
+        },
+        resolve: (
+          source: { body?: string | null },
+          args: { pruneLength: number },
+        ) => {
+          const body = source.body ?? ""
+          const cleaned = body
+            // fenced code blocks
+            .replace(/```[\s\S]*?```/g, "")
+            // ATX headings (# 〜 ######)
+            .replace(/^[ \t]*#{1,6}[ \t].*$/gm, "")
+            // Setext headings (underlined with === or ---)
+            .replace(/^.+\n[=-]{2,}\s*$/gm, "")
+            // images
+            .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
+            // links: keep the text
+            .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+            // blockquote / list markers at line start
+            .replace(/^[ \t]*[>\-*+][ \t]+/gm, "")
+            // inline code: keep the text
+            .replace(/`([^`]+)`/g, "$1")
+            // emphasis markers
+            .replace(/[*_~]/g, "")
+            // collapse whitespace
+            .replace(/\s+/g, " ")
+            .trim()
+          if (cleaned.length <= args.pruneLength) return cleaned
+          return `${cleaned.slice(0, args.pruneLength).trimEnd()}…`
+        },
+      },
+    },
+  })
+}
+
 export const createPages: GatsbyNode["createPages"] = ({ actions }) => {
   const { createSlice } = actions
   createSlice({


### PR DESCRIPTION
## 関連 Issue

close #2

## 概要

記事の `excerpt`（一覧やメタ情報で使われる要約）に `## はじめに` のような見出しのテキストが含まれてしまい、要約として不自然になる問題を修正する。

gatsby-plugin-mdx 標準の `excerpt` リゾルバは MDX 全体をテキスト化するため見出しの文字も拾ってしまっていた。`gatsby-node.ts` の `createResolvers` で `Mdx.excerpt` を上書きし、見出し・コードブロック・画像などを除外したうえで本文の地の文だけを抽出するようにした。

### 変更内容

- `gatsby-node.ts` に `createResolvers` を追加し、`Mdx.excerpt` リゾルバを差し替え
- 抽出対象から除外するもの:
  - ATX 見出し（`#` 〜 `######`）
  - Setext 見出し（`===` / `---` の下線形式）
  - フェンスドコードブロック
  - 画像（`![alt](url)`）
  - リスト・引用の行頭マーカー、強調記号
- リンク・インラインコードは表示テキストだけを残す
- 連続する空白を 1 個に潰し、`pruneLength`（既定 140）で切り詰め

## 動作確認方法

1. `pnpm run typecheck` がエラーなく通ること
2. `pnpm run build` がエラーなく完了すること
3. ビルド後、`React Hook で Todo アプリを作る` 記事のように本文が `## はじめに` から始まる記事の excerpt が、見出し文字を含まず本文（`React16.8 で追加された...`）から始まっていること
4. トップページ・一覧ページの記事カードを見て、要約が見出しではなく地の文から始まっていること

## 伝達事項

- gatsby-plugin-mdx 標準の `rehype-infer-description-meta` ベースの excerpt 生成は使わなくなる。今後 MDX 構文木ベースの抽出が必要になった場合は別フィールドを切るなどの検討が必要。
- 現状の記事は基本的に通常の Markdown 記法のため正規表現ベースで十分だが、JSX コンポーネントを多用する MDX が増えた場合は調整が必要になる可能性がある。

## レビューに関して

レビューする際には、以下のprefix(接頭辞)を付けましょう。

| ラベル | 意味                            | 意図                                                               |
| ------ | ------------------------------- | ------------------------------------------------------------------ |
| q      | 質問 (Question)                 | 質問。相手は回答が必要                                             |
| fyi    | 参考まで (For your information) | 参考までに共有。アクションは不要 (確認事項を残す場合などに使用)    |
| nits   | あら捜し (Nitpick)              | 重箱の隅をつつく提案。無視しても良い                               |
| nir    | お手すきで (No rush)            | 今やらなくて良いが、将来的には解決したい提案。タスク化や修正を検討 |
| imo    | 提案 (In my opinion)            | 個人的な見解や、軽微な提案。タスク化や修正を検討                   |
| must   | 必須 (Must)                     | これを直さないと承認できない。修正を検討                           |